### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## Version 4.1.0 - 12.12.2024
+* Fixes critical Bug in the way leveled lists are generated
+* Adds pre-generation logging to better inform users about what the app will generate with their chosen settings.
+* disable individual item logging by default since it blocks the more useful pre-generation logging and has a negative impact on performance
+* Added a math based safety net for the rarity weight setting.
+
+(No runtime estimates this time)
+
 ## Version 4.0.0 - 23.11.2024
 * Added [Syllabore](https://github.com/kesac/Syllabore) support for Name Generation
 * Made the Names more variable and not fully stuck with what their EditorID would be.

--- a/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
+++ b/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
@@ -254,7 +254,7 @@ namespace SynthesisRPGLoot.Analyzers
                 {
                     return rarityClass.HideRarityLabelInName 
                         ? $"{ConfiguredNameGenerator.Next()} of {GetEnchantmentsStringForName(effects)}" 
-                        : $"{rarityClass.Label} of {GetEnchantmentsStringForName(effects)}";
+                        : $"{rarityClass.Label} {ConfiguredNameGenerator.Next()} of {GetEnchantmentsStringForName(effects)}";
                 }
                 case GeneratedNameScheme.AsItemNameReplacingEnchantments:
                 {

--- a/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
+++ b/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
@@ -58,7 +58,7 @@ namespace SynthesisRPGLoot.Analyzers
         private readonly LeveledListFlagSettings _leveledListFlagSettings =
             Program.Settings.GeneralSettings.LeveledListFlagSettings;
 
-        private readonly string _enchantmentSeparatorString = 
+        private readonly string _enchantmentSeparatorString =
             Program.Settings.NameGeneratorSettings.EnchantmentSeparator;
 
         private readonly string _lastEnchantmentSeparatorString =
@@ -76,6 +76,54 @@ namespace SynthesisRPGLoot.Analyzers
 
         protected abstract void AnalyzeGear();
 
+        public void CalculateStats()
+        {
+            BaseItems = RarityAndVariationDistributionSettings.LeveledListBase switch
+            {
+                LeveledListBase.AllValidEnchantedItems => AllEnchantedItems,
+                LeveledListBase.AllValidUnenchantedItems => AllUnenchantedItems,
+                _ => BaseItems
+            };
+
+            var uniqueBaseItemCount = BaseItems.Select(item => item.Resolved.FormKey).Distinct().ToHashSet().Count;
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine($"Number of Base Items : {uniqueBaseItemCount}");
+            Console.WriteLine($"Number of Base LeveldListEntries: {BaseItems.Count}");
+            Console.WriteLine($"Number of Classes per Item: {RarityClasses.Count}");
+            Console.WriteLine($"Number of Variations per Rarity: {VarietyCountPerRarity}");
+            Console.WriteLine(
+                $"Number of Unique LeveledLists to Create : {uniqueBaseItemCount * (RarityClasses.Count + 1)}");
+            Console.WriteLine(
+                $"Number of unique new Items to Generate : {uniqueBaseItemCount * RarityClasses.Count * VarietyCountPerRarity}");
+            Console.WriteLine($"Total number of RPG Loot Patcher \"touched\" & new Leveled List Entries: {
+                BaseItems.Count
+                * (GearSettings.BaseItemChanceWeight
+                   + RarityClasses.Select(r =>
+                           (int) r.RarityWeight)
+                       .ToArray()
+                       .Sum()
+                   * VarietyCountPerRarity)}"
+            );
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine(
+                "Rarity Chances in Percent: \n" +
+                "(not perfect since they only impact the new additions relative to any existing loot chances)");
+            var rarityWeightsSum = RarityClasses.Select(r =>
+                    (int) r.RarityWeight)
+                .ToArray()
+                .Sum()+GearSettings.BaseItemChanceWeight;
+            Console.WriteLine($"BaseItem Chance: {(float)GearSettings.BaseItemChanceWeight/rarityWeightsSum:P2}");
+            foreach (var rarityClass in RarityClasses)
+            {
+                
+                Console.WriteLine($"{rarityClass.Label} Chance: {(float)rarityClass.RarityWeight/rarityWeightsSum:P2}");
+            }
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+        }
+
         public void Generate()
         {
             BaseItems = RarityAndVariationDistributionSettings.LeveledListBase switch
@@ -89,7 +137,7 @@ namespace SynthesisRPGLoot.Analyzers
             {
                 var entries = State.PatchMod.LeveledItems
                     .GetOrAddAsOverride(ench.List).Entries?.Where(entry =>
-                    entry.Data?.Reference.FormKey == ench.Resolved.FormKey);
+                        entry.Data?.Reference.FormKey == ench.Resolved.FormKey);
 
                 if (entries == null) continue;
                 if (ench.Entry.Data == null) continue;
@@ -108,7 +156,7 @@ namespace SynthesisRPGLoot.Analyzers
                     topLevelList.Entries = [];
                     topLevelList.EditorID = topLevelListEditorId;
                     topLevelList.Flags = GetLeveledItemFlags();
-                    
+
                     for (var i = 0; i < GearSettings.BaseItemChanceWeight; i++)
                     {
                         var oldEntryChanceAdjustmentCopy = ench.Entry.DeepCopy();
@@ -120,7 +168,8 @@ namespace SynthesisRPGLoot.Analyzers
 
                     foreach (var rarityClass in RarityClasses)
                     {
-                        var leveledItemEditorId = $"HAL_SUB_LList_{rarityClass.Label}_{ench.Resolved.EditorID}_Level_{levelForName}";
+                        var leveledItemEditorId =
+                            $"HAL_SUB_LList_{rarityClass.Label}_{ench.Resolved.EditorID}_Level_{levelForName}";
                         LeveledItem leveledItem;
                         if (State.LinkCache.TryResolve<ILeveledItemGetter>(leveledItemEditorId,
                                 out var leveledItemGetter))
@@ -246,14 +295,14 @@ namespace SynthesisRPGLoot.Analyzers
             {
                 case GeneratedNameScheme.DontUse:
                 {
-                    return rarityClass.HideRarityLabelInName 
-                        ? $"{itemName} of {GetEnchantmentsStringForName(effects)}" 
+                    return rarityClass.HideRarityLabelInName
+                        ? $"{itemName} of {GetEnchantmentsStringForName(effects)}"
                         : $"{rarityClass.Label} {itemName} of {GetEnchantmentsStringForName(effects)}";
                 }
                 case GeneratedNameScheme.AsItemName:
                 {
-                    return rarityClass.HideRarityLabelInName 
-                        ? $"{ConfiguredNameGenerator.Next()} of {GetEnchantmentsStringForName(effects)}" 
+                    return rarityClass.HideRarityLabelInName
+                        ? $"{ConfiguredNameGenerator.Next()} of {GetEnchantmentsStringForName(effects)}"
                         : $"{rarityClass.Label} {ConfiguredNameGenerator.Next()} of {GetEnchantmentsStringForName(effects)}";
                 }
                 case GeneratedNameScheme.AsItemNameReplacingEnchantments:

--- a/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
+++ b/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
@@ -94,7 +94,8 @@ namespace SynthesisRPGLoot.Analyzers
                 if (entries == null) continue;
                 if (ench.Entry.Data == null) continue;
                 if (ench.List?.Entries == null) continue;
-                var topLevelListEditorId = "HAL_TOP_LList_" + ench.Resolved.EditorID;
+                var levelForName = ench.Entry.Data.Level;
+                var topLevelListEditorId = $"HAL_TOP_LList_{ench.Resolved.EditorID}_Level_{levelForName}";
                 LeveledItem topLevelList;
                 if (State.LinkCache.TryResolve<ILeveledItemGetter>(topLevelListEditorId, out var topLeveledListGetter))
                 {
@@ -119,7 +120,7 @@ namespace SynthesisRPGLoot.Analyzers
 
                     foreach (var rarityClass in RarityClasses)
                     {
-                        var leveledItemEditorId = "HAL_SUB_LList_" + rarityClass.Label + "_" + ench.Resolved.EditorID;
+                        var leveledItemEditorId = $"HAL_SUB_LList_{rarityClass.Label}_{ench.Resolved.EditorID}_Level_{levelForName}";
                         LeveledItem leveledItem;
                         if (State.LinkCache.TryResolve<ILeveledItemGetter>(leveledItemEditorId,
                                 out var leveledItemGetter))

--- a/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
+++ b/SynthesisRPGLoot/Analyzers/GearAnalyzer.cs
@@ -104,9 +104,15 @@ namespace SynthesisRPGLoot.Analyzers
                 {
                     topLevelList = State.PatchMod.LeveledItems.AddNewLocking(State.PatchMod.GetNextFormKey());
                     topLevelList.DeepCopyIn(ench.List);
-                    topLevelList.Entries?.Clear();
+                    topLevelList.Entries = [];
                     topLevelList.EditorID = topLevelListEditorId;
                     topLevelList.Flags = GetLeveledItemFlags();
+                    
+                    for (var i = 0; i < GearSettings.BaseItemChanceWeight; i++)
+                    {
+                        var oldEntryChanceAdjustmentCopy = ench.Entry.DeepCopy();
+                        topLevelList.Entries.Add(oldEntryChanceAdjustmentCopy);
+                    }
 
                     var rarityClassNumber = 0;
 
@@ -124,7 +130,7 @@ namespace SynthesisRPGLoot.Analyzers
                         {
                             leveledItem = State.PatchMod.LeveledItems.AddNewLocking(State.PatchMod.GetNextFormKey());
                             leveledItem.DeepCopyIn(ench.List);
-                            leveledItem.Entries = new ();
+                            leveledItem.Entries = [];
                             leveledItem.EditorID = leveledItemEditorId;
                             leveledItem.Flags = GetLeveledItemFlags();
 
@@ -156,13 +162,6 @@ namespace SynthesisRPGLoot.Analyzers
                 foreach (var entry in entries)
                 {
                     entry.Data.Reference.SetTo(topLevelList);
-                }
-
-
-                for (var i = 0; i < GearSettings.BaseItemChanceWeight; i++)
-                {
-                    var oldEntryChanceAdjustmentCopy = ench.Entry.DeepCopy();
-                    topLevelList.Entries.Add(oldEntryChanceAdjustmentCopy);
                 }
             }
         }

--- a/SynthesisRPGLoot/Program.cs
+++ b/SynthesisRPGLoot/Program.cs
@@ -28,7 +28,7 @@ namespace SynthesisRPGLoot
 
         private static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
-            
+            //TODO:
             Console.WriteLine("DEBUGGING");
             
             // Workaround for VR Support until Mutagen adds support for the 1.71 header in VR

--- a/SynthesisRPGLoot/Program.cs
+++ b/SynthesisRPGLoot/Program.cs
@@ -28,9 +28,7 @@ namespace SynthesisRPGLoot
 
         private static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
-            //TODO:
-            Console.WriteLine("DEBUGGING");
-            
+
             // Workaround for VR Support until Mutagen adds support for the 1.71 header in VR
             if (state.PatchMod.ModHeader.Stats.NextFormID <= 0x800)
             {
@@ -45,6 +43,9 @@ namespace SynthesisRPGLoot
             var armor = new ArmorAnalyzer(state, objectEffectsAnalyzer);
             var weapon = new WeaponAnalyzer(state, objectEffectsAnalyzer);
             
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            
             Console.WriteLine("Analyzing mod list");
             var th1 = new Thread(() => armor.Analyze());
             var th2 = new Thread(() => weapon.Analyze());
@@ -53,12 +54,46 @@ namespace SynthesisRPGLoot
             th2.Start();
             th1.Join();
             th2.Join();
+
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("Calculating Output Statistics For Comparison:");
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("Armor Statistics:");
+            armor.CalculateStats();
+            
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("Weapon Statistics:");
+            weapon.CalculateStats();
+            
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            
+            Console.WriteLine("Please consider the Calculations above when you think the next steps take too long.");
+            Console.WriteLine("This patcher will take a long time on bigger setups.");
+            Console.WriteLine("If your runtime reaches more than 40min or more than an hour, then you should dial down\n" +
+                              "The amount of Variations per Rarity and maybe even the amount of Rarities you are using.\n" +
+                              "Because long generation times will also mean longer loading times for the game\n" +
+                              "and possible instabilities since the Engine wasn't made for such insanities.");
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
             
             Console.WriteLine("Generating armor enchantments");
             armor.Generate();
+            Console.WriteLine("Done Generating armor enchantments");
             
             Console.WriteLine("Generating weapon enchantments");
             weapon.Generate();
+            Console.WriteLine("Done Generating weapon enchantments");
+            
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
+            Console.WriteLine(
+                "------------------------------------------------------------------------------------------------------");
 
             Console.WriteLine("\n" +
                               " _                 _     _____                _           _   \n" +

--- a/SynthesisRPGLoot/Program.cs
+++ b/SynthesisRPGLoot/Program.cs
@@ -57,16 +57,16 @@ namespace SynthesisRPGLoot
 
             Console.WriteLine(
                 "------------------------------------------------------------------------------------------------------");
-            Console.WriteLine("Calculating Output Statistics For Comparison:");
+            Console.WriteLine("Pre-Generation Checks by doing some Math with the chosen Settings:");
             Console.WriteLine(
                 "------------------------------------------------------------------------------------------------------");
-            Console.WriteLine("Armor Statistics:");
-            armor.CalculateStats();
+            Console.WriteLine("Armor Pre-Generation Checks:");
+            armor.PreGenerationCheck();
             
             Console.WriteLine(
                 "------------------------------------------------------------------------------------------------------");
-            Console.WriteLine("Weapon Statistics:");
-            weapon.CalculateStats();
+            Console.WriteLine("Weapon Pre-Generation Checks:");
+            weapon.PreGenerationCheck();
             
             Console.WriteLine(
                 "------------------------------------------------------------------------------------------------------");

--- a/SynthesisRPGLoot/Program.cs
+++ b/SynthesisRPGLoot/Program.cs
@@ -28,6 +28,9 @@ namespace SynthesisRPGLoot
 
         private static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
+            
+            Console.WriteLine("DEBUGGING");
+            
             // Workaround for VR Support until Mutagen adds support for the 1.71 header in VR
             if (state.PatchMod.ModHeader.Stats.NextFormID <= 0x800)
             {

--- a/SynthesisRPGLoot/Settings/GeneralSettings.cs
+++ b/SynthesisRPGLoot/Settings/GeneralSettings.cs
@@ -17,7 +17,7 @@ public class GeneralSettings
     
     [MaintainOrder]
     [SynthesisTooltip("Disabling this can speed up the generation process.")]
-    public bool LogGeneratedItems = true;
+    public bool LogGeneratedItems = false;
         
     [MaintainOrder]
     [SynthesisSettingName("LeveledList Flags")]

--- a/SynthesisRPGLoot/SynthesisRPGLoot.csproj
+++ b/SynthesisRPGLoot/SynthesisRPGLoot.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.48.0" />
-    <PackageReference Include="Mutagen.Bethesda.Core" Version="0.48.0" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.32.0" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.48.1" />
+    <PackageReference Include="Mutagen.Bethesda.Core" Version="0.48.1" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.32.1" />
     <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="3.4.0" />
     <PackageReference Include="Syllabore" Version="2.3.4" />
   </ItemGroup>


### PR DESCRIPTION
- Fixes critical Bug in the way leveled lists are generated 
- Adds pre-generation logging to better inform users about what the app will generate with their chosen settings.
- disable individual item logging by default since it blocks the more useful pre-generation logging and has a negative impact on performance
- Added a math based safety net for the rarity weight setting.